### PR TITLE
Fix noindent test to run

### DIFF
--- a/test/suite/parser/parserSpec.ts
+++ b/test/suite/parser/parserSpec.ts
@@ -33,7 +33,6 @@ describe("ReVIEW構文の", () => {
             let path = "test/fixture/valid/";
 
             let ignoreFiles = [
-                "block_dont_has_body.re", // noindent がまだサポートされていない
                 "ch01.re", // lead, emplist がまだサポートされていない
             ];
             function matchIgnoreFiles(filePath: string) {


### PR DESCRIPTION
In actual, "noindent" had been implemented correctly, so this test should be executed normally.